### PR TITLE
add ".idea" to the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ coverage/
 dist
 
 test/test.db.json
+
+.idea


### PR DESCRIPTION
In order to keep the project IDE-agnostic, the local configuration files maintained by IntelliJ IDEA have been excluded from the repository.